### PR TITLE
fix plugin-development.html page 404

### DIFF
--- a/docs/en-us/developer_guide/plugin-development.md
+++ b/docs/en-us/developer_guide/plugin-development.md
@@ -1,0 +1,3 @@
+## Translation is not ready.
+
+

--- a/docs/en-us/developer_guide/plugin-development.md
+++ b/docs/en-us/developer_guide/plugin-development.md
@@ -1,3 +1,0 @@
-## Translation is not ready.
-
-

--- a/index.html
+++ b/index.html
@@ -1,1 +1,18 @@
-hello dolphinscheduler!
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+</head>
+<body>
+  <script src="//cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
+	<script>
+    window.rootPath = '';
+    window.defaultLanguage = 'en-us';
+    var lang = Cookies.get('docsite_language');
+    if (!lang) {
+      lang = 'en-us';
+    }
+    window.location = window.rootPath + '/' + lang;
+  </script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2090,9 +2090,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
       "dev": true
     },
     "commondir": {
@@ -2703,7 +2703,7 @@
         "chalk": "2.4.2",
         "chokidar": "2.1.8",
         "co": "4.6.0",
-        "commander": "2.20.0",
+        "commander": "2.20.1",
         "css-modules-require-hook": "4.2.3",
         "ejs": "2.7.1",
         "fs-extra": "6.0.1",

--- a/site_config/docs.js
+++ b/site_config/docs.js
@@ -34,10 +34,6 @@ export default {
             link: '/en-us/docs/developer_guide/backend-development.html',
           },
           {
-            title: 'Plugin Development',
-            link: '/en-us/docs/developer_guide/plugin-development.html',
-          },
-          {
             title: 'Frontend Development',
             link: '/en-us/docs/developer_guide/frontend-development.html',
           },


### PR DESCRIPTION
Fix the bug that https://dolphinscheduler.incubator.apache.org/en-us/docs/developer_guide/plugin-development.html page is 404. The page will show  "translation is not ready".