### PR TITLE
[Improvement-4421][docs] The MySQL JDBC driver version requirements are described in the documentation

### DIFF
--- a/docs/en-us/1.3.4/user_doc/cluster-deployment.md
+++ b/docs/en-us/1.3.4/user_doc/cluster-deployment.md
@@ -2,7 +2,7 @@
 
 # 1、Before you begin (please install requirement basic software by yourself)
 
- * PostgreSQL (8.2.15+) or MySQL (5.7)  :  Choose One
+ * PostgreSQL (8.2.15+) or MySQL (5.7)  :  Choose One, JDBC Driver 5.1.47+ is required if MySQL is used
  * [JDK](https://www.oracle.com/technetwork/java/javase/downloads/index.html) (1.8+) :  Required. Double-check configure JAVA_HOME and PATH environment variables in /etc/profile
  * ZooKeeper (3.4.6+) ：Required
  * Hadoop (2.6+) or MinIO ：Optional. If you need to upload a resource function, you can choose a local file directory as the upload folder for a single machine (this operation does not need to deploy Hadoop). Of course, you can also choose to upload to Hadoop or MinIO.

--- a/docs/en-us/1.3.4/user_doc/standalone-deployment.md
+++ b/docs/en-us/1.3.4/user_doc/standalone-deployment.md
@@ -2,7 +2,7 @@
 
 # 1、Install basic softwares (please install required softwares by yourself)
 
- * PostgreSQL (8.2.15+) or MySQL (5.7)  :  Choose One
+ * PostgreSQL (8.2.15+) or MySQL (5.7)  :  Choose One, JDBC Driver 5.1.47+ is required if MySQL is used
  * [JDK](https://www.oracle.com/technetwork/java/javase/downloads/index.html) (1.8+) :  Required. Double-check configure JAVA_HOME and PATH environment variables in /etc/profile
  * ZooKeeper (3.4.6+) ：Required
  * Hadoop (2.6+) or MinIO ：Optional. If you need resource function, for Standalone Deployment you can choose a local directory as the upload destination (this does not need Hadoop deployed). Of course, you can also choose to upload to Hadoop or MinIO.

--- a/docs/zh-cn/1.3.4/user_doc/cluster-deployment.md
+++ b/docs/zh-cn/1.3.4/user_doc/cluster-deployment.md
@@ -2,7 +2,7 @@
 
 # 1、基础软件安装(必装项请自行安装)
 
- * PostgreSQL (8.2.15+) or MySQL (5.7系列)  :  两者任选其一即可
+ * PostgreSQL (8.2.15+) or MySQL (5.7系列)  :  两者任选其一即可, 如MySQL则需要JDBC Driver 5.1.47+
  * [JDK](https://www.oracle.com/technetwork/java/javase/downloads/index.html) (1.8+) :  必装，请安装好后在/etc/profile下配置 JAVA_HOME 及 PATH 变量
  * ZooKeeper (3.4.6+) ：必装 
  * Hadoop (2.6+) or MinIO ：选装，如果需要用到资源上传功能，可以选择上传到Hadoop or MinIO上

--- a/docs/zh-cn/1.3.4/user_doc/standalone-deployment.md
+++ b/docs/zh-cn/1.3.4/user_doc/standalone-deployment.md
@@ -2,7 +2,7 @@
 
 # 1、基础软件安装(必装项请自行安装)
 
- * PostgreSQL (8.2.15+) or MySQL (5.7系列)  :  两者任选其一即可
+ * PostgreSQL (8.2.15+) or MySQL (5.7系列)  :  两者任选其一即可, 如MySQL则需要JDBC Driver 5.1.47+
  * [JDK](https://www.oracle.com/technetwork/java/javase/downloads/index.html) (1.8+) :  必装，请安装好后在/etc/profile下配置 JAVA_HOME 及 PATH 变量
  * ZooKeeper (3.4.6+) ：必装 
  * Hadoop (2.6+) or MinIO ：选装， 如果需要用到资源上传功能，针对单机可以选择本地文件目录作为上传文件夹(此操作不需要部署Hadoop)；当然也可以选择上传到Hadoop or MinIO集群上


### PR DESCRIPTION
A clearer requirement on mysql jdbc driver version in document (like 5.1.47+) would save people from hitting such annoying serious problem. 
Which version of DolphinScheduler: 1.3.4