### PR TITLE
Fix cache problem of js/css/html/json and optimize build and render speed

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "start": "docsite start",
     "build": "docsite build",
-    "lint": "eslint --ext .js,.jsx ./src ./utils ./site_config ./gulpfile.js ./webpack.config.js",
-    "lint:fix": "eslint --ext .js,.jsx --fix ./src ./utils ./site_config ./gulpfile.js ./webpack.config.js"
+    "report": "report_analyzer=true docsite build",
+    "lint": "eslint --ext .js,.jsx src utils site_config gulpfile.js webpack.config.js",
+    "lint:fix": "eslint --ext .js,.jsx --fix src utils site_config gulpfile.js webpack.config.js"
   },
   "dependencies": {
     "antd": "^3.26.20",
@@ -34,11 +35,12 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "babel-register": "^6.26.0",
+    "clean-webpack-plugin": "^2.0.2",
     "commander": "^2.20.3",
     "copy-webpack-plugin": "^4.6.0",
     "css-loader": "0.28.11",
     "css-modules-require-hook": "^4.2.3",
-    "docsite-ext": "^1.4.4",
+    "docsite-ext": "^1.5.0",
     "eslint": "^5.16.0",
     "eslint-config-ali": "^4.1.1",
     "eslint-plugin-import": "*",
@@ -51,11 +53,13 @@
     "node-libs-browser": "2.2.1",
     "node-sass": "^4.14.1",
     "opn": "^5.3.0",
-    "postcss": "^6.0.23",
+    "optimize-css-assets-webpack-plugin": "^3.2.1",
     "raw-loader": "^0.5.1",
     "sass-loader": "7.3.1",
     "style-loader": "0.6.5",
     "webpack": "^3.12.0",
-    "webpack-dev-server": "2.11.5"
+    "webpack-bundle-analyzer": "^4.4.0",
+    "webpack-dev-server": "2.11.5",
+    "webpack-manifest-plugin": "^2.2.0"
   }
 }

--- a/redirect.ejs
+++ b/redirect.ejs
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
   <title>Apache DolphinScheduler is a distributed and easy-to-extend visual workflow scheduler system, dedicated to solving the complex task dependencies in data processing, making the scheduling system out of the box for data processing.</title>
-  <meta charset="UTF-8"/>
-  <meta name="description" content="Apache DolphinScheduler is a distributed and easy-to-extend visual workflow scheduler system, dedicated to solving the complex task dependencies in data processing, making the scheduling system out of the box for data processing."/>
-  <meta name="keywords" content="Apache DolphinScheduler Official Website,dolphinscheduler.apache.org"/>
-  <link rel="shortcut icon" href="<%= rootPath %>/img/favicon.ico"/>
+  <meta charset="UTF-8">
+  <meta name="description" content="Apache DolphinScheduler is a distributed and easy-to-extend visual workflow scheduler system, dedicated to solving the complex task dependencies in data processing, making the scheduling system out of the box for data processing.">
+  <meta name="keywords" content="Apache DolphinScheduler Official Website,dolphinscheduler.apache.org">
+  <link rel="shortcut icon" href="<%= rootPath %>/img/favicon.ico">
 </head>
 <body>
   <script src="//cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>

--- a/site_config/community.jsx
+++ b/site_config/community.jsx
@@ -240,7 +240,6 @@ export default {
           },
           {
             title: '订阅邮件列表',
-            target: '_blank',
             link: '/zh-cn/community/development/subscribe.html',
           },
           {

--- a/site_config/site.js
+++ b/site_config/site.js
@@ -3,6 +3,7 @@ export default {
   rootPath: '', // 发布到服务器的根目录，需以/开头但不能有尾/，如果只有/，请填写空字符串
   port: 8080, // 本地开发服务器的启动端口
   domain: 'dolphinscheduler.incubator.apache.org', // 站点部署域名，无需协议和path等
+  copyToDist: ['img', 'file', '.asf.yaml', 'sitemap.xml', '.nojekyll'], // 当build发布时，需要额外复制到dist目录的资源，默认有：index.html, 404.html, en-us, zh-cn, build
   defaultSearch: 'google', // 默认搜索引擎，baidu或者google
   defaultLanguage: 'en-us',
   'en-us': {

--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -4,9 +4,9 @@ import classnames from 'classnames';
 import { autobind } from 'core-decorators';
 import siteConfig from '../../../site_config/site';
 import { getLink } from '../../../utils';
-import 'antd/dist/antd.css';
+import Menu from 'antd/lib/menu';
+import 'antd/lib/menu/style/index.css';
 import './index.scss';
-import { Menu } from 'antd';
 
 const { SubMenu } = Menu;
 const languageSwitch = [

--- a/src/components/md2html/index.jsx
+++ b/src/components/md2html/index.jsx
@@ -17,7 +17,7 @@ const Md2Html = ComposeComponent => class extends ComposeComponent {
 
   componentDidMount() {
     // 通过请求获取生成好的json数据，静态页和json文件在同一个目录下
-    fetch(window.location.pathname.replace(/\.html$/i, '.json'))
+    fetch(`${window.location.pathname.replace(/\.html$/i, '.json')}?t=${new Date().getTime()}`)
       .then(res => res.json())
       .then((md) => {
         this.setState({

--- a/src/pages/blog/index.md.scss
+++ b/src/pages/blog/index.md.scss
@@ -1,7 +1,4 @@
 @import '../../variables.scss';
-@import '../../reset.scss';
-@import '../../markdown.scss';
-
 .blog-detail-page {
   .blog-content {
     padding: 80px 20%;

--- a/src/pages/home/index.scss
+++ b/src/pages/home/index.scss
@@ -1,5 +1,6 @@
 @import '../../variables.scss';
 @import '../../reset.scss';
+
 @keyframes slashStar {
   0% {
     opacity: 1; }

--- a/src/reset.scss
+++ b/src/reset.scss
@@ -1,5 +1,3 @@
-@import './markdown.scss';
-
 * {
 	padding: 0;
 	margin: 0;

--- a/template.ejs
+++ b/template.ejs
@@ -3,18 +3,31 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-  <meta name="keywords" content="<%= keywords %>" />
-  <meta name="description" content="<%= description %>" />
+  <meta name="keywords" content="<%= keywords %>">
+  <meta name="description" content="<%= description %>">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <title><%= title %></title>
-  <link rel="shortcut icon" href="<%= rootPath %>/img/favicon.ico"/>
-  <link rel="stylesheet" href="<%= rootPath %>/build/<%= page %>.css" />
+  <link rel="shortcut icon" href="<%= rootPath %>/img/favicon.ico">
+  <%_ if (vendorCssPath) { _%>
+  <link rel="stylesheet" href="<%= rootPath %>/build/<%= vendorCssPath %>">
+  <%_ } _%>
+  <%_ if (pageCssPath) { _%>
+  <link rel="stylesheet" href="<%= rootPath %>/build/<%= pageCssPath %>">
+  <%_ } _%>
 </head>
 <body>
   <div id="root"><%- __html %></div>
-  <script src="https://f.alicdn.com/react/15.4.1/react-with-addons.min.js"></script>
-  <script src="https://f.alicdn.com/react/15.4.1/react-dom.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/react@15.6.2/dist/react-with-addons.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/react-dom@15.6.2/dist/react-dom.min.js"></script>
   <script>window.rootPath = '<%= rootPath %>';</script>
-  <script src="<%= rootPath %>/build/<%= page %>.js"></script>
+  <%_ if (vendorJsPath) { _%>
+  <script src="<%= rootPath %>/build/<%= vendorJsPath %>"></script>
+  <%_ } _%>
+  <%_ if (pageJsPath) { _%>
+  <script src="<%= rootPath %>/build/<%= pageJsPath %>"></script>
+  <%_ } _%>
   <script>
     var _hmt = _hmt || [];
     (function() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,5 @@ module.exports = {
   plugins: [
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.optimize.OccurrenceOrderPlugin(),
-    new ExtractTextPlugin('[name].css'),
   ],
 };


### PR DESCRIPTION
### Brief Changes

1. **Fix cache problem of js/css/html/json**

- `js`: hash added like `home.f781a31.js`
- `css`: hash added like `home.f8be930.css`
- `html`: http-equiv added to prevent cache
```
<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
<meta http-equiv="Pragma" content="no-cache">
<meta http-equiv="Expires" content="0">
```
- `json`: query parameter added like `t=1613928167854`

2. **Optimize package size significantly**

- Use ant design component on demand instead of full library (2.4MB) import, because we just use `Menu` component of it
- Extract common js and css into `vendor` like `vendor.45714e5.js` and `vendor.23ece49.css` which are almost unchanged
- Other package size of js and css resource have been significantly reduced

_The package size of js/css resource in the past:_
![image](https://user-images.githubusercontent.com/4902714/108633626-2cd2a300-74b0-11eb-8e2b-e15983600611.png)

_The package size of js/css resource at current time:_
![image](https://user-images.githubusercontent.com/4902714/108633594-0f9dd480-74b0-11eb-84a2-fdd050d77f39.png)

3. **Optimize build and render speed significantly**

The build speed has been significantly reduced to 26 seconds from 113.2 seconds

_The build speed in the past:_
![image](https://user-images.githubusercontent.com/4902714/108633197-f6942400-74ad-11eb-9337-3ae4ab43e48f.png)
_The build speed at current time:_
![image](https://user-images.githubusercontent.com/4902714/108633207-027fe600-74ae-11eb-82a2-dc4f44502cce.png)

And render speed of accessing the official website also has been significantly decreased

4. **Add `copyToDist` config in `site_config/site.js` to copy additional resources to dist directory which is the build directory**
![image](https://user-images.githubusercontent.com/4902714/108633732-c8fcaa00-74b0-11eb-9408-4ed198d1bcd5.png)

@dailidong @break60 @CalvinKirs 