### PR TITLE
Update standalone-deployment.md

### DIFF
--- a/docs/en-us/1.3.1/user_doc/standalone-deployment.md
+++ b/docs/en-us/1.3.1/user_doc/standalone-deployment.md
@@ -263,6 +263,7 @@ mysql -uroot -p
 
 
     # if not use hadoop resourcemanager, please keep default value; if resourcemanager HA enable, please type the HA ips ; if resourcemanager is single, make this value empty
+    # Note: For tasks that depend on YARN to execute, you need to ensure that YARN information is configured correctly in order to ensure successful execution results.
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # if resourcemanager HA enable or not use resourcemanager, please skip this value setting; If resourcemanager is single, you only need to replace yarnIp1 to actual resourcemanager hostname.

--- a/docs/en-us/1.3.2/user_doc/standalone-deployment.md
+++ b/docs/en-us/1.3.2/user_doc/standalone-deployment.md
@@ -208,6 +208,7 @@ mysql -uroot -p
     defaultFS="file:///data/dolphinscheduler"
 
     # if not use hadoop resourcemanager, please keep default value; if resourcemanager HA enable, please type the HA ips ; if resourcemanager is single, make this value empty
+    # Note: For tasks that depend on YARN to execute, you need to ensure that YARN information is configured correctly in order to ensure successful execution results.
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # if resourcemanager HA enable or not use resourcemanager, please skip this value setting; If resourcemanager is single, you only need to replace yarnIp1 to actual resourcemanager hostname.

--- a/docs/en-us/1.3.3/user_doc/standalone-deployment.md
+++ b/docs/en-us/1.3.3/user_doc/standalone-deployment.md
@@ -208,6 +208,7 @@ mysql -uroot -p
     defaultFS="file:///data/dolphinscheduler"
 
     # if not use hadoop resourcemanager, please keep default value; if resourcemanager HA enable, please type the HA ips ; if resourcemanager is single, make this value empty
+    # Note: For tasks that depend on YARN to execute, you need to ensure that YARN information is configured correctly in order to ensure successful execution results.
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # if resourcemanager HA enable or not use resourcemanager, please skip this value setting; If resourcemanager is single, you only need to replace yarnIp1 to actual resourcemanager hostname.

--- a/docs/en-us/1.3.4/user_doc/standalone-deployment.md
+++ b/docs/en-us/1.3.4/user_doc/standalone-deployment.md
@@ -208,6 +208,7 @@ mysql -uroot -p
     defaultFS="file:///data/dolphinscheduler"
 
     # if not use hadoop resourcemanager, please keep default value; if resourcemanager HA enable, please type the HA ips ; if resourcemanager is single, make this value empty
+    # Note: For tasks that depend on YARN to execute, you need to ensure that YARN information is configured correctly in order to ensure successful execution results.
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # if resourcemanager HA enable or not use resourcemanager, please skip this value setting; If resourcemanager is single, you only need to replace yarnIp1 to actual resourcemanager hostname.

--- a/docs/en-us/1.3.5/user_doc/standalone-deployment.md
+++ b/docs/en-us/1.3.5/user_doc/standalone-deployment.md
@@ -208,6 +208,7 @@ mysql -uroot -p
     defaultFS="file:///data/dolphinscheduler"
 
     # if not use hadoop resourcemanager, please keep default value; if resourcemanager HA enable, please type the HA ips ; if resourcemanager is single, make this value empty
+    # Note: For tasks that depend on YARN to execute, you need to ensure that YARN information is configured correctly in order to ensure successful execution results.
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # if resourcemanager HA enable or not use resourcemanager, please skip this value setting; If resourcemanager is single, you only need to replace yarnIp1 to actual resourcemanager hostname.

--- a/docs/zh-cn/1.3.1/user_doc/standalone-deployment.md
+++ b/docs/zh-cn/1.3.1/user_doc/standalone-deployment.md
@@ -201,6 +201,7 @@ mysql -uroot -p
     defaultFS="file:///data/dolphinscheduler"    #hdfs://{具体的ip/主机名}:8020
 
     # 如果没有使用到Yarn,保持以下默认值即可；如果ResourceManager是HA，则配置为ResourceManager节点的主备ip或者hostname,比如"192.168.xx.xx,192.168.xx.xx";如果是单ResourceManager请配置yarnHaIps=""即可
+    # 注：依赖于yarn执行的任务，为了保证执行结果判断成功,需要确保yarn信息配置正确。
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # 如果ResourceManager是HA或者没有使用到Yarn保持默认值即可；如果是单ResourceManager，请配置真实的ResourceManager主机名或者ip

--- a/docs/zh-cn/1.3.2/user_doc/standalone-deployment.md
+++ b/docs/zh-cn/1.3.2/user_doc/standalone-deployment.md
@@ -201,6 +201,7 @@ mysql -uroot -p
     defaultFS="file:///data/dolphinscheduler"    #hdfs://{具体的ip/主机名}:8020
 
     # 如果没有使用到Yarn,保持以下默认值即可；如果ResourceManager是HA，则配置为ResourceManager节点的主备ip或者hostname,比如"192.168.xx.xx,192.168.xx.xx";如果是单ResourceManager请配置yarnHaIps=""即可
+    # 注：依赖于yarn执行的任务，为了保证执行结果判断成功,需要确保yarn信息配置正确。
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # 如果ResourceManager是HA或者没有使用到Yarn保持默认值即可；如果是单ResourceManager，请配置真实的ResourceManager主机名或者ip

--- a/docs/zh-cn/1.3.3/user_doc/standalone-deployment.md
+++ b/docs/zh-cn/1.3.3/user_doc/standalone-deployment.md
@@ -201,6 +201,7 @@ mysql -uroot -p
     defaultFS="file:///data/dolphinscheduler"    #hdfs://{具体的ip/主机名}:8020
 
     # 如果没有使用到Yarn,保持以下默认值即可；如果ResourceManager是HA，则配置为ResourceManager节点的主备ip或者hostname,比如"192.168.xx.xx,192.168.xx.xx";如果是单ResourceManager请配置yarnHaIps=""即可
+    # 注：依赖于yarn执行的任务，为了保证执行结果判断成功,需要确保yarn信息配置正确。
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # 如果ResourceManager是HA或者没有使用到Yarn保持默认值即可；如果是单ResourceManager，请配置真实的ResourceManager主机名或者ip

--- a/docs/zh-cn/1.3.4/user_doc/standalone-deployment.md
+++ b/docs/zh-cn/1.3.4/user_doc/standalone-deployment.md
@@ -201,6 +201,7 @@ mysql -uroot -p
     defaultFS="file:///data/dolphinscheduler"    #hdfs://{具体的ip/主机名}:8020
 
     # 如果没有使用到Yarn,保持以下默认值即可；如果ResourceManager是HA，则配置为ResourceManager节点的主备ip或者hostname,比如"192.168.xx.xx,192.168.xx.xx";如果是单ResourceManager请配置yarnHaIps=""即可
+    # 注：依赖于yarn执行的任务，为了保证执行结果判断成功,需要确保yarn信息配置正确。
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # 如果ResourceManager是HA或者没有使用到Yarn保持默认值即可；如果是单ResourceManager，请配置真实的ResourceManager主机名或者ip

--- a/docs/zh-cn/1.3.5/user_doc/standalone-deployment.md
+++ b/docs/zh-cn/1.3.5/user_doc/standalone-deployment.md
@@ -201,6 +201,7 @@ mysql -uroot -p
     defaultFS="file:///data/dolphinscheduler"    #hdfs://{具体的ip/主机名}:8020
 
     # 如果没有使用到Yarn,保持以下默认值即可；如果ResourceManager是HA，则配置为ResourceManager节点的主备ip或者hostname,比如"192.168.xx.xx,192.168.xx.xx";如果是单ResourceManager请配置yarnHaIps=""即可
+    # 注：依赖于yarn执行的任务，为了保证执行结果判断成功,需要确保yarn信息配置正确。
     yarnHaIps="192.168.xx.xx,192.168.xx.xx"
 
     # 如果ResourceManager是HA或者没有使用到Yarn保持默认值即可；如果是单ResourceManager，请配置真实的ResourceManager主机名或者ip


### PR DESCRIPTION
Depends on the tasks executed by yarn. As a result, it is necessary to determine the success information in the script and the yarn ui at the same time. If the yarn ip is not configured, tasks such as spark will be executed successfully, but dolphinscheduler shows this task failed. Add some comments to remind people who are doing stand-alone testing.

---

依赖于yarn执行的任务， 结果需要同时判定脚本和yarn的页面中的success信息， 如果不配置yarn的信息， 会导致spark之类的任务执行成功了， 但是dolphin显示任务失败。增加一些备注信息，避免其他人在做单机测试的时候出现此类问题。